### PR TITLE
Fixed UnitTest failing on non english machine

### DIFF
--- a/Src/PCLMock/Utility/ObjectExtensions.cs
+++ b/Src/PCLMock/Utility/ObjectExtensions.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Reflection;
     using System.Text;
 
@@ -94,17 +95,17 @@
 
             if (@this is float)
             {
-                return @this.ToString() + "F";
+                return ((float)@this).ToString(CultureInfo.InvariantCulture) + "F";
             }
 
             if (@this is double)
             {
-                return @this.ToString() + "D";
+                return ((double)@this).ToString(CultureInfo.InvariantCulture) + "D";
             }
 
             if (@this is decimal)
             {
-                return @this.ToString() + "M";
+                return ((decimal)@this).ToString(CultureInfo.InvariantCulture) + "M";
             }
 
             if (@this is Enum)


### PR DESCRIPTION
On my device with German language settings, some Unit tests failed because a `,` is used for floating points as default.

Therefore  `3.461M.ToDebugString()` produced `3,461M` instead of `3.461M`.

Using `CultureInfo.InvariantCulture` fixed the problem.
