### PR TITLE
Microsoft.code analysis update

### DIFF
--- a/Src/PCLMock.CodeGeneration.Console/App.config
+++ b/Src/PCLMock.CodeGeneration.Console/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
     </startup>
     <runtime>
         <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/Src/PCLMock.CodeGeneration.Console/PCLMock.CodeGeneration.Console.csproj
+++ b/Src/PCLMock.CodeGeneration.Console/PCLMock.CodeGeneration.Console.csproj
@@ -34,74 +34,117 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="PowerArgs, Version=2.8.0.0, Culture=neutral, PublicKeyToken=26a276264bbd55b8, processorArchitecture=MSIL">
       <HintPath>..\packages\PowerArgs.2.8.0.0\lib\net45\PowerArgs.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Convention, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Convention.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Hosting, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Hosting.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Runtime, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Runtime.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfoCommon.cs">
@@ -123,8 +166,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/PCLMock.CodeGeneration.Console/PCLMock.CodeGeneration.Console.csproj
+++ b/Src/PCLMock.CodeGeneration.Console/PCLMock.CodeGeneration.Console.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PCLMock.CodeGeneration.Console</RootNamespace>
     <AssemblyName>PCLMockCodeGen</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/Src/PCLMock.CodeGeneration.Console/packages.config
+++ b/Src/PCLMock.CodeGeneration.Console/packages.config
@@ -1,21 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.8.2" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="PowerArgs" version="2.8.0.0" targetFramework="net452" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net452" />
+  <package id="System.Composition" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Convention" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Hosting" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Runtime" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.TypedParts" version="1.0.31" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net452" />
@@ -24,7 +41,22 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/Src/PCLMock.CodeGeneration.T4/PCLMock.CodeGeneration.T4.csproj
+++ b/Src/PCLMock.CodeGeneration.T4/PCLMock.CodeGeneration.T4.csproj
@@ -31,70 +31,113 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Convention, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Convention.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Hosting, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Hosting.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Runtime, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Runtime.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reflection.Metadata, Version=1.4.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfoCommon.cs">
@@ -125,8 +168,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/PCLMock.CodeGeneration.T4/PCLMock.CodeGeneration.T4.csproj
+++ b/Src/PCLMock.CodeGeneration.T4/PCLMock.CodeGeneration.T4.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PCLMock.CodeGeneration.T4</RootNamespace>
     <AssemblyName>PCLMock.CodeGeneration.T4</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Src/PCLMock.CodeGeneration.T4/app.config
+++ b/Src/PCLMock.CodeGeneration.T4/app.config
@@ -28,4 +28,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/Src/PCLMock.CodeGeneration.T4/packages.config
+++ b/Src/PCLMock.CodeGeneration.T4/packages.config
@@ -1,20 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.8.2" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net452" />
+  <package id="System.Composition" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Convention" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Hosting" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Runtime" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.TypedParts" version="1.0.31" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net452" />
@@ -23,7 +40,22 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/Src/PCLMock.CodeGeneration/PCLMock.CodeGeneration.csproj
+++ b/Src/PCLMock.CodeGeneration/PCLMock.CodeGeneration.csproj
@@ -31,61 +31,71 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Convention, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Convention.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Hosting, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Hosting.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Runtime, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Runtime.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
@@ -106,11 +116,44 @@
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfoCommon.cs">
@@ -153,8 +196,8 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Src/PCLMock.CodeGeneration/PCLMock.CodeGeneration.csproj
+++ b/Src/PCLMock.CodeGeneration/PCLMock.CodeGeneration.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PCLMock.CodeGeneration</RootNamespace>
     <AssemblyName>PCLMock.CodeGeneration</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Src/PCLMock.CodeGeneration/app.config
+++ b/Src/PCLMock.CodeGeneration/app.config
@@ -28,4 +28,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/Src/PCLMock.CodeGeneration/packages.config
+++ b/Src/PCLMock.CodeGeneration/packages.config
@@ -1,25 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.8.2" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net452" />
+  <package id="System.Composition" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Convention" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Hosting" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Runtime" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.TypedParts" version="1.0.31" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net452" />
@@ -28,7 +45,22 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/DuplicateMemberOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/DuplicateMemberOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::IThirdInterface>, global::IThirdInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/GenericInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/GenericInterfaceOutput_CSharp.txt
@@ -2,9 +2,10 @@
 {
     [System.CodeDom.Compiler.GeneratedCode("PCLMock", "$VERSION$")]
     [System.Runtime.CompilerServices.CompilerGenerated]
-    public partial class Mock<TFirst, TSecond> : global::PCLMock.MockBase<global::IGenericInterface<TFirst, TSecond>>, global::IGenericInterface<TFirst, TSecond> where TFirst : global::System.IComparable<TSecond>, new ()where TSecond : struct
+    public partial class Mock<TFirst, TSecond> : global::PCLMock.MockBase<global::IGenericInterface<TFirst, TSecond>>, global::IGenericInterface<TFirst, TSecond> where TFirst : global::System.IComparable<TSecond>, new()
+        where TSecond : struct
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/IndexersOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/IndexersOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 this[System.Int32 i]
+        public global::System.Int32 this[global::System.Int32 i]
         {
             get
             {
@@ -33,7 +33,7 @@
             }
         }
 
-        public System.String this[System.Int32 i, System.Single j]
+        public global::System.String this[global::System.Int32 i, global::System.Single j]
         {
             get
             {
@@ -41,7 +41,7 @@
             }
         }
 
-        public System.String this[System.Int32 i, System.Single j, System.Double d]
+        public global::System.String this[global::System.Int32 i, global::System.Single j, global::System.Double d]
         {
             get
             {

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InheritingInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InheritingInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::IInheritingInterface>, global::IInheritingInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 SomeProperty
+        public global::System.Int32 SomeProperty
         {
             get
             {
@@ -33,7 +33,7 @@
             }
         }
 
-        public System.Object Clone()
+        public global::System.Object Clone()
         {
             return this.Apply(x => x.Clone());
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InterfaceWithGenericMethodsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InterfaceWithGenericMethodsOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::IInterfaceWithGenericMethods>, global::IInterfaceWithGenericMethods
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -35,7 +35,7 @@
             return this.Apply(x => x.NonVoidMethodWithGenericParameter<T>());
         }
 
-        public void VoidMethodWithGenericArguments<TFirst, TSecond, TThird>(TFirst first, TSecond second, TThird third, System.String somethingElse)
+        public void VoidMethodWithGenericArguments<TFirst, TSecond, TThird>(TFirst first, TSecond second, TThird third, global::System.String somethingElse)
         {
             this.Apply(x => x.VoidMethodWithGenericArguments<TFirst, TSecond, TThird>(first, second, third, somethingElse));
         }
@@ -45,7 +45,9 @@
             return this.Apply(x => x.NonVoidMethodWithGenericArguments<TFirst, TSecond>(input));
         }
 
-        public TSecond MethodWithTypeConstraints<TFirst, TSecond>(TFirst input, System.Int32 option)where TFirst : IComparable<TFirst>, new ()where TSecond : struct
+        public TSecond MethodWithTypeConstraints<TFirst, TSecond>(TFirst input, global::System.Int32 option)
+            where TFirst : IComparable<TFirst>, new()
+            where TSecond : struct
         {
             return this.Apply(x => x.MethodWithTypeConstraints<TFirst, TSecond>(input, option));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InternalInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/InternalInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::IInternalInterface>, global::IInternalInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 GetProperty
+        public global::System.Int32 GetProperty
         {
             get
             {
@@ -33,7 +33,7 @@
             }
         }
 
-        public System.Int32 GetSetProperty
+        public global::System.Int32 GetSetProperty
         {
             get
             {
@@ -51,17 +51,17 @@
             this.Apply(x => x.VoidMethod());
         }
 
-        public void VoidMethodWithArguments(System.Int32 i, System.String s)
+        public void VoidMethodWithArguments(global::System.Int32 i, global::System.String s)
         {
             this.Apply(x => x.VoidMethodWithArguments(i, s));
         }
 
-        public System.String NonVoidMethod()
+        public global::System.String NonVoidMethod()
         {
             return this.Apply(x => x.NonVoidMethod());
         }
 
-        public System.String NonVoidMethodWithArguments(System.Int32 i, System.String s)
+        public global::System.String NonVoidMethodWithArguments(global::System.Int32 i, global::System.String s)
         {
             return this.Apply(x => x.NonVoidMethodWithArguments(i, s));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/NameClashOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/NameClashOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 this[System.Int32 x]
+        public global::System.Int32 this[global::System.Int32 x]
         {
             get
             {
@@ -38,20 +38,20 @@
             }
         }
 
-        public void SomeMethod(System.Int32 x)
+        public void SomeMethod(global::System.Int32 x)
         {
             this.Apply(_x => _x.SomeMethod(x));
         }
 
-        public void SomeMethod(System.Int32 x, System.Int32 _x)
+        public void SomeMethod(global::System.Int32 x, global::System.Int32 _x)
         {
             this.Apply(__x => __x.SomeMethod(x, _x));
         }
 
-        public void SomeMethod(out System.Single f, System.Single _f)
+        public void SomeMethod(out global::System.Single f, global::System.Single _f)
         {
-            System.Single __f;
-            f = (this.GetOutParameterValue<System.Single>(x => x.SomeMethod(out __f, _f), 0));
+            global::System.Single __f;
+            f = (this.GetOutParameterValue<global::System.Single>(x => x.SomeMethod(out __f, _f), 0));
             this.Apply(x => x.SomeMethod(out __f, _f));
         }
     }

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/NonMockableMembersOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/NonMockableMembersOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::IInterfaceWithNonMockableMembers>, global::IInterfaceWithNonMockableMembers
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 SomeProperty
+        public global::System.Int32 SomeProperty
         {
             get
             {

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/OutAndRefOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/OutAndRefOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,42 +25,42 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public void SomeMethod(out System.Int32 i)
+        public void SomeMethod(out global::System.Int32 i)
         {
-            System.Int32 _i;
-            i = (this.GetOutParameterValue<System.Int32>(x => x.SomeMethod(out _i), 0));
+            global::System.Int32 _i;
+            i = (this.GetOutParameterValue<global::System.Int32>(x => x.SomeMethod(out _i), 0));
             this.Apply(x => x.SomeMethod(out _i));
         }
 
-        public void SomeMethod(out System.Double d, System.Int32 i)
+        public void SomeMethod(out global::System.Double d, global::System.Int32 i)
         {
-            System.Double _d;
-            d = (this.GetOutParameterValue<System.Double>(x => x.SomeMethod(out _d, i), 0));
+            global::System.Double _d;
+            d = (this.GetOutParameterValue<global::System.Double>(x => x.SomeMethod(out _d, i), 0));
             this.Apply(x => x.SomeMethod(out _d, i));
         }
 
-        public void SomeMethod(System.Int32 i, out System.Double d)
+        public void SomeMethod(global::System.Int32 i, out global::System.Double d)
         {
-            System.Double _d;
-            d = (this.GetOutParameterValue<System.Double>(x => x.SomeMethod(i, out _d), 1));
+            global::System.Double _d;
+            d = (this.GetOutParameterValue<global::System.Double>(x => x.SomeMethod(i, out _d), 1));
             this.Apply(x => x.SomeMethod(i, out _d));
         }
 
-        public void SomeMethod(ref System.Int32 i, out System.String s)
+        public void SomeMethod(ref global::System.Int32 i, out global::System.String s)
         {
-            var _i = default (System.Int32);
-            System.String _s;
-            i = (this.GetRefParameterValue<System.Int32>(x => x.SomeMethod(ref _i, out _s), 0));
-            s = (this.GetOutParameterValue<System.String>(x => x.SomeMethod(ref _i, out _s), 1));
+            var _i = default(global::System.Int32);
+            global::System.String _s;
+            i = (this.GetRefParameterValue<global::System.Int32>(x => x.SomeMethod(ref _i, out _s), 0));
+            s = (this.GetOutParameterValue<global::System.String>(x => x.SomeMethod(ref _i, out _s), 1));
             this.Apply(x => x.SomeMethod(ref _i, out _s));
         }
 
-        public void SomeMethod(ref System.Int32 i, out System.String s, System.Double d)
+        public void SomeMethod(ref global::System.Int32 i, out global::System.String s, global::System.Double d)
         {
-            var _i = default (System.Int32);
-            System.String _s;
-            i = (this.GetRefParameterValue<System.Int32>(x => x.SomeMethod(ref _i, out _s, d), 0));
-            s = (this.GetOutParameterValue<System.String>(x => x.SomeMethod(ref _i, out _s, d), 1));
+            var _i = default(global::System.Int32);
+            global::System.String _s;
+            i = (this.GetRefParameterValue<global::System.Int32>(x => x.SomeMethod(ref _i, out _s, d), 0));
+            s = (this.GetOutParameterValue<global::System.String>(x => x.SomeMethod(ref _i, out _s, d), 1));
             this.Apply(x => x.SomeMethod(ref _i, out _s, d));
         }
     }

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/PartialInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/PartialInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::IPartialInterface>, global::IPartialInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 Property1
+        public global::System.Int32 Property1
         {
             get
             {
@@ -33,7 +33,7 @@
             }
         }
 
-        public System.Int32 Property2
+        public global::System.Int32 Property2
         {
             get
             {

--- a/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/SimpleInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/GeneratorFixtureResources/SimpleInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@
     [System.Runtime.CompilerServices.CompilerGenerated]
     public partial class Mock : global::PCLMock.MockBase<global::ISimpleInterface>, global::ISimpleInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 GetProperty
+        public global::System.Int32 GetProperty
         {
             get
             {
@@ -33,7 +33,7 @@
             }
         }
 
-        public System.Int32 GetSetProperty
+        public global::System.Int32 GetSetProperty
         {
             get
             {
@@ -51,17 +51,17 @@
             this.Apply(x => x.VoidMethod());
         }
 
-        public void VoidMethodWithArguments(System.Int32 i, System.String s)
+        public void VoidMethodWithArguments(global::System.Int32 i, global::System.String s)
         {
             this.Apply(x => x.VoidMethodWithArguments(i, s));
         }
 
-        public System.String NonVoidMethod()
+        public global::System.String NonVoidMethod()
         {
             return this.Apply(x => x.NonVoidMethod());
         }
 
-        public System.String NonVoidMethodWithArguments(System.Int32 i, System.String s)
+        public global::System.String NonVoidMethodWithArguments(global::System.Int32 i, global::System.String s)
         {
             return this.Apply(x => x.NonVoidMethodWithArguments(i, s));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/CollectionsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/CollectionsOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomCollection<T>>, global::ICustomCollection<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -43,22 +43,22 @@ namespace The.Namespace
             this.Apply(x => x.Clear());
         }
 
-        public System.Boolean Contains(T item)
+        public global::System.Boolean Contains(T item)
         {
             return this.Apply(x => x.Contains(item));
         }
 
-        public void CopyTo(T[] array, System.Int32 arrayIndex)
+        public void CopyTo(T[] array, global::System.Int32 arrayIndex)
         {
             this.Apply(x => x.CopyTo(array, arrayIndex));
         }
 
-        public System.Boolean Remove(T item)
+        public global::System.Boolean Remove(T item)
         {
             return this.Apply(x => x.Remove(item));
         }
 
-        public System.Int32 Count
+        public global::System.Int32 Count
         {
             get
             {
@@ -66,7 +66,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Boolean IsReadOnly
+        public global::System.Boolean IsReadOnly
         {
             get
             {
@@ -86,7 +86,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -99,10 +99,10 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<System.Int32>());
-            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.List<System.Int32>());
-            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<System.String>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.List<System.String>());
+            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<global::System.Int32>());
+            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.List<global::System.Int32>());
+            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<global::System.String>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.List<global::System.String>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -111,7 +111,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.ICollection<System.Int32> SomeProperty
+        public global::System.Collections.Generic.ICollection<global::System.Int32> SomeProperty
         {
             get
             {
@@ -119,7 +119,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IReadOnlyCollection<System.Int32> SomeReadOnlyProperty
+        public global::System.Collections.Generic.IReadOnlyCollection<global::System.Int32> SomeReadOnlyProperty
         {
             get
             {
@@ -127,17 +127,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.ICollection<System.String> SomeMethod()
+        public global::System.Collections.Generic.ICollection<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.ICollection<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.ICollection<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Generic.ICollection<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Generic.ICollection<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -147,7 +147,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomCollection<System.Int32> SomeCustomProperty
+        public global::ICustomCollection<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -155,12 +155,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomCollection<System.String> SomeMethod()
+        public global::ICustomCollection<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomCollection<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomCollection<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -172,7 +172,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -187,7 +187,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<T>());
             this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<T>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.List<T>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.List<T>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -209,7 +209,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.ICollection<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.ICollection<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/DictionariesOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/DictionariesOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<TKey, TValue> : global::PCLMock.MockBase<global::ICustomDictionary<TKey, TValue>>, global::ICustomDictionary<TKey, TValue>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -35,7 +35,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Boolean ContainsKey(TKey key)
+        public global::System.Boolean ContainsKey(TKey key)
         {
             return this.Apply(x => x.ContainsKey(key));
         }
@@ -45,12 +45,12 @@ namespace The.Namespace
             this.Apply(x => x.Add(key, value));
         }
 
-        public System.Boolean Remove(TKey key)
+        public global::System.Boolean Remove(TKey key)
         {
             return this.Apply(x => x.Remove(key));
         }
 
-        public System.Boolean TryGetValue(TKey key, out TValue value)
+        public global::System.Boolean TryGetValue(TKey key, out TValue value)
         {
             TValue _value;
             value = (this.GetOutParameterValue<TValue>(x => x.TryGetValue(key, out _value), 1));
@@ -96,22 +96,22 @@ namespace The.Namespace
             this.Apply(x => x.Clear());
         }
 
-        public System.Boolean Contains(global::System.Collections.Generic.KeyValuePair<TKey, TValue> item)
+        public global::System.Boolean Contains(global::System.Collections.Generic.KeyValuePair<TKey, TValue> item)
         {
             return this.Apply(x => x.Contains(item));
         }
 
-        public void CopyTo(global::System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, System.Int32 arrayIndex)
+        public void CopyTo(global::System.Collections.Generic.KeyValuePair<TKey, TValue>[] array, global::System.Int32 arrayIndex)
         {
             this.Apply(x => x.CopyTo(array, arrayIndex));
         }
 
-        public System.Boolean Remove(global::System.Collections.Generic.KeyValuePair<TKey, TValue> item)
+        public global::System.Boolean Remove(global::System.Collections.Generic.KeyValuePair<TKey, TValue> item)
         {
             return this.Apply(x => x.Remove(item));
         }
 
-        public System.Int32 Count
+        public global::System.Int32 Count
         {
             get
             {
@@ -119,7 +119,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Boolean IsReadOnly
+        public global::System.Boolean IsReadOnly
         {
             get
             {
@@ -134,7 +134,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -147,10 +147,10 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.Dictionary<System.Int32, System.String>());
-            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.Dictionary<System.Int32, System.String>());
-            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.Dictionary<System.Int32, System.String>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.Dictionary<System.Int32, System.String>());
+            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.Dictionary<global::System.Int32, global::System.String>());
+            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.Dictionary<global::System.Int32, global::System.String>());
+            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.Dictionary<global::System.Int32, global::System.String>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.Dictionary<global::System.Int32, global::System.String>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -159,7 +159,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.IDictionary<System.Int32, System.String> SomeProperty
+        public global::System.Collections.Generic.IDictionary<global::System.Int32, global::System.String> SomeProperty
         {
             get
             {
@@ -167,7 +167,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IReadOnlyDictionary<System.Int32, System.String> SomeReadOnlyProperty
+        public global::System.Collections.Generic.IReadOnlyDictionary<global::System.Int32, global::System.String> SomeReadOnlyProperty
         {
             get
             {
@@ -175,27 +175,27 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IDictionary<System.Int32, System.String> SomeMethod()
+        public global::System.Collections.Generic.IDictionary<global::System.Int32, global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IDictionary<System.Int32, System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IDictionary<global::System.Int32, global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Generic.IDictionary<System.Int32, System.String> SomeGenericMethod<T>()
+        public global::System.Collections.Generic.IDictionary<global::System.Int32, global::System.String> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
 
-        public global::System.Collections.Generic.IDictionary<System.Int32, T> SomeOtherGenericMethod<T>()
+        public global::System.Collections.Generic.IDictionary<global::System.Int32, T> SomeOtherGenericMethod<T>()
         {
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomDictionary<System.Int32, System.String> SomeCustomProperty
+        public global::ICustomDictionary<global::System.Int32, global::System.String> SomeCustomProperty
         {
             get
             {
@@ -203,12 +203,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomDictionary<System.Int32, System.String> SomeMethod()
+        public global::ICustomDictionary<global::System.Int32, global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomDictionary<System.Int32, System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomDictionary<global::System.Int32, global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -220,7 +220,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<TKey, TValue> : global::PCLMock.MockBase<global::ISomeGenericInterface<TKey, TValue>>, global::ISomeGenericInterface<TKey, TValue>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -235,7 +235,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.Dictionary<TKey, TValue>());
             this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.Dictionary<TKey, TValue>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.Dictionary<TKey, TValue>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.Dictionary<TKey, TValue>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -257,7 +257,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IDictionary<TKey, TValue> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IDictionary<TKey, TValue> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/EnumerablesOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/EnumerablesOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomEnumerable<T>>, global::ICustomEnumerable<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -50,7 +50,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -63,9 +63,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Linq.Enumerable.Empty<System.Int32>());
-            this.When(x => x.SomeMethod()).Return(global::System.Linq.Enumerable.Empty<System.String>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Linq.Enumerable.Empty<System.String>());
+            this.When(x => x.SomeProperty).Return(global::System.Linq.Enumerable.Empty<global::System.Int32>());
+            this.When(x => x.SomeMethod()).Return(global::System.Linq.Enumerable.Empty<global::System.String>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Linq.Enumerable.Empty<global::System.String>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -74,7 +74,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.IEnumerable<System.Int32> SomeProperty
+        public global::System.Collections.Generic.IEnumerable<global::System.Int32> SomeProperty
         {
             get
             {
@@ -82,17 +82,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IEnumerable<System.String> SomeMethod()
+        public global::System.Collections.Generic.IEnumerable<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IEnumerable<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IEnumerable<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Generic.IEnumerable<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Generic.IEnumerable<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -102,7 +102,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomEnumerable<System.Int32> SomeCustomProperty
+        public global::ICustomEnumerable<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -110,12 +110,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomEnumerable<System.String> SomeMethod()
+        public global::ICustomEnumerable<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomEnumerable<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomEnumerable<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -127,7 +127,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -142,7 +142,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Linq.Enumerable.Empty<T>());
             this.When(x => x.SomeMethod()).Return(global::System.Linq.Enumerable.Empty<T>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Linq.Enumerable.Empty<T>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Linq.Enumerable.Empty<T>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -164,7 +164,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IEnumerable<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IEnumerable<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableDictionariesOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableDictionariesOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<TKey, TValue> : global::PCLMock.MockBase<global::ICustomImmutableDictionary<TKey, TValue>>, global::ICustomImmutableDictionary<TKey, TValue>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -75,12 +75,12 @@ namespace The.Namespace
             return this.Apply(x => x.Remove(key));
         }
 
-        public System.Boolean Contains(global::System.Collections.Generic.KeyValuePair<TKey, TValue> pair)
+        public global::System.Boolean Contains(global::System.Collections.Generic.KeyValuePair<TKey, TValue> pair)
         {
             return this.Apply(x => x.Contains(pair));
         }
 
-        public System.Boolean TryGetKey(TKey equalKey, out TKey actualKey)
+        public global::System.Boolean TryGetKey(TKey equalKey, out TKey actualKey)
         {
             TKey _actualKey;
             actualKey = (this.GetOutParameterValue<TKey>(x => x.TryGetKey(equalKey, out _actualKey), 1));
@@ -94,7 +94,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -107,9 +107,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableDictionary<System.Int32, System.String>.Empty);
-            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableDictionary<System.Int32, System.String>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableDictionary<System.Int32, System.String>.Empty);
+            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableDictionary<global::System.Int32, global::System.String>.Empty);
+            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableDictionary<global::System.Int32, global::System.String>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableDictionary<global::System.Int32, global::System.String>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -118,7 +118,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Immutable.IImmutableDictionary<System.Int32, System.String> SomeProperty
+        public global::System.Collections.Immutable.IImmutableDictionary<global::System.Int32, global::System.String> SomeProperty
         {
             get
             {
@@ -126,27 +126,27 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Immutable.IImmutableDictionary<System.Int32, System.String> SomeMethod()
+        public global::System.Collections.Immutable.IImmutableDictionary<global::System.Int32, global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableDictionary<System.Int32, System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableDictionary<global::System.Int32, global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Immutable.IImmutableDictionary<System.Int32, System.String> SomeGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableDictionary<global::System.Int32, global::System.String> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
 
-        public global::System.Collections.Immutable.IImmutableDictionary<System.Int32, T> SomeOtherGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableDictionary<global::System.Int32, T> SomeOtherGenericMethod<T>()
         {
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomImmutableDictionary<System.Int32, System.String> SomeCustomProperty
+        public global::ICustomImmutableDictionary<global::System.Int32, global::System.String> SomeCustomProperty
         {
             get
             {
@@ -154,12 +154,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomImmutableDictionary<System.Int32, System.String> SomeMethod()
+        public global::ICustomImmutableDictionary<global::System.Int32, global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomImmutableDictionary<System.Int32, System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomImmutableDictionary<global::System.Int32, global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -171,7 +171,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<TKey, TValue> : global::PCLMock.MockBase<global::ISomeGenericInterface<TKey, TValue>>, global::ISomeGenericInterface<TKey, TValue>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -186,7 +186,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableDictionary<TKey, TValue>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -208,7 +208,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableDictionary<TKey, TValue> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableListsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableListsOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomImmutableList<T>>, global::ICustomImmutableList<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -28,14 +28,14 @@ namespace The.Namespace
             this.When(x => x.Clear()).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.Add(global::PCLMock.It.IsAny<T>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.AddRange(global::PCLMock.It.IsAny<global::System.Collections.Generic.IEnumerable<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.Insert(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<T>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.InsertRange(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<global::System.Collections.Generic.IEnumerable<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.Insert(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<T>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.InsertRange(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Collections.Generic.IEnumerable<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.Remove(global::PCLMock.It.IsAny<T>(), global::PCLMock.It.IsAny<global::System.Collections.Generic.IEqualityComparer<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.RemoveAll(global::PCLMock.It.IsAny<global::System.Predicate<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.RemoveRange(global::PCLMock.It.IsAny<global::System.Collections.Generic.IEnumerable<T>>(), global::PCLMock.It.IsAny<global::System.Collections.Generic.IEqualityComparer<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.RemoveRange(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Int32>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.RemoveAt(global::PCLMock.It.IsAny<System.Int32>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.SetItem(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<T>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.RemoveRange(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Int32>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.RemoveAt(global::PCLMock.It.IsAny<global::System.Int32>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.SetItem(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<T>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.Replace(global::PCLMock.It.IsAny<T>(), global::PCLMock.It.IsAny<T>(), global::PCLMock.It.IsAny<global::System.Collections.Generic.IEqualityComparer<T>>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
         }
 
@@ -50,12 +50,12 @@ namespace The.Namespace
             return this.Apply(x => x.Clear());
         }
 
-        public System.Int32 IndexOf(T item, System.Int32 index, System.Int32 count, global::System.Collections.Generic.IEqualityComparer<T> equalityComparer)
+        public global::System.Int32 IndexOf(T item, global::System.Int32 index, global::System.Int32 count, global::System.Collections.Generic.IEqualityComparer<T> equalityComparer)
         {
             return this.Apply(x => x.IndexOf(item, index, count, equalityComparer));
         }
 
-        public System.Int32 LastIndexOf(T item, System.Int32 index, System.Int32 count, global::System.Collections.Generic.IEqualityComparer<T> equalityComparer)
+        public global::System.Int32 LastIndexOf(T item, global::System.Int32 index, global::System.Int32 count, global::System.Collections.Generic.IEqualityComparer<T> equalityComparer)
         {
             return this.Apply(x => x.LastIndexOf(item, index, count, equalityComparer));
         }
@@ -70,12 +70,12 @@ namespace The.Namespace
             return this.Apply(x => x.AddRange(items));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> Insert(System.Int32 index, T element)
+        public global::System.Collections.Immutable.IImmutableList<T> Insert(global::System.Int32 index, T element)
         {
             return this.Apply(x => x.Insert(index, element));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> InsertRange(System.Int32 index, global::System.Collections.Generic.IEnumerable<T> items)
+        public global::System.Collections.Immutable.IImmutableList<T> InsertRange(global::System.Int32 index, global::System.Collections.Generic.IEnumerable<T> items)
         {
             return this.Apply(x => x.InsertRange(index, items));
         }
@@ -95,17 +95,17 @@ namespace The.Namespace
             return this.Apply(x => x.RemoveRange(items, equalityComparer));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> RemoveRange(System.Int32 index, System.Int32 count)
+        public global::System.Collections.Immutable.IImmutableList<T> RemoveRange(global::System.Int32 index, global::System.Int32 count)
         {
             return this.Apply(x => x.RemoveRange(index, count));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> RemoveAt(System.Int32 index)
+        public global::System.Collections.Immutable.IImmutableList<T> RemoveAt(global::System.Int32 index)
         {
             return this.Apply(x => x.RemoveAt(index));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> SetItem(System.Int32 index, T value)
+        public global::System.Collections.Immutable.IImmutableList<T> SetItem(global::System.Int32 index, T value)
         {
             return this.Apply(x => x.SetItem(index, value));
         }
@@ -122,7 +122,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -135,9 +135,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableList<System.Int32>.Empty);
-            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableList<System.String>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableList<System.String>.Empty);
+            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableList<global::System.Int32>.Empty);
+            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableList<global::System.String>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableList<global::System.String>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -146,7 +146,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Immutable.IImmutableList<System.Int32> SomeProperty
+        public global::System.Collections.Immutable.IImmutableList<global::System.Int32> SomeProperty
         {
             get
             {
@@ -154,17 +154,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Immutable.IImmutableList<System.String> SomeMethod()
+        public global::System.Collections.Immutable.IImmutableList<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableList<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableList<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Immutable.IImmutableList<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableList<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -174,7 +174,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public ICustomIImmutableList<System.Int32> SomeCustomProperty
+        public ICustomIImmutableList<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -182,12 +182,12 @@ namespace The.Namespace
             }
         }
 
-        public ICustomIImmutableList<System.String> SomeMethod()
+        public ICustomIImmutableList<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public ICustomIImmutableList<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public ICustomIImmutableList<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -199,7 +199,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -214,7 +214,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableList<T>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -236,7 +236,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableList<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableList<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableQueuesOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableQueuesOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomImmutableQueue<T>>, global::ICustomImmutableQueue<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -56,7 +56,7 @@ namespace The.Namespace
             return this.Apply(x => x.Dequeue());
         }
 
-        public System.Boolean IsEmpty
+        public global::System.Boolean IsEmpty
         {
             get
             {
@@ -71,7 +71,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -84,9 +84,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableQueue<System.Int32>.Empty);
-            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableQueue<System.String>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableQueue<System.String>.Empty);
+            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableQueue<global::System.Int32>.Empty);
+            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableQueue<global::System.String>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableQueue<global::System.String>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -95,7 +95,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Immutable.IImmutableQueue<System.Int32> SomeProperty
+        public global::System.Collections.Immutable.IImmutableQueue<global::System.Int32> SomeProperty
         {
             get
             {
@@ -103,17 +103,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Immutable.IImmutableQueue<System.String> SomeMethod()
+        public global::System.Collections.Immutable.IImmutableQueue<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableQueue<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableQueue<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Immutable.IImmutableQueue<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableQueue<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -123,7 +123,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public ICustomIImmutableQueue<System.Int32> SomeCustomProperty
+        public ICustomIImmutableQueue<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -131,12 +131,12 @@ namespace The.Namespace
             }
         }
 
-        public ICustomIImmutableQueue<System.String> SomeMethod()
+        public ICustomIImmutableQueue<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public ICustomIImmutableQueue<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public ICustomIImmutableQueue<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -148,7 +148,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -163,7 +163,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableQueue<T>.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableQueue<T>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableQueue<T>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableQueue<T>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -185,7 +185,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableQueue<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableQueue<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableSetsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableSetsOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomImmutableSet<T>>, global::ICustomImmutableSet<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -45,7 +45,7 @@ namespace The.Namespace
             return this.Apply(x => x.Clear());
         }
 
-        public System.Boolean Contains(T value)
+        public global::System.Boolean Contains(T value)
         {
             return this.Apply(x => x.Contains(value));
         }
@@ -60,7 +60,7 @@ namespace The.Namespace
             return this.Apply(x => x.Remove(value));
         }
 
-        public System.Boolean TryGetValue(T equalValue, out T actualValue)
+        public global::System.Boolean TryGetValue(T equalValue, out T actualValue)
         {
             T _actualValue;
             actualValue = (this.GetOutParameterValue<T>(x => x.TryGetValue(equalValue, out _actualValue), 1));
@@ -87,32 +87,32 @@ namespace The.Namespace
             return this.Apply(x => x.Union(other));
         }
 
-        public System.Boolean SetEquals(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean SetEquals(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.SetEquals(other));
         }
 
-        public System.Boolean IsProperSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsProperSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsProperSubsetOf(other));
         }
 
-        public System.Boolean IsProperSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsProperSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsProperSupersetOf(other));
         }
 
-        public System.Boolean IsSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsSubsetOf(other));
         }
 
-        public System.Boolean IsSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsSupersetOf(other));
         }
 
-        public System.Boolean Overlaps(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean Overlaps(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.Overlaps(other));
         }
@@ -124,7 +124,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -137,9 +137,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableHashSet<System.Int32>.Empty);
-            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableHashSet<System.String>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableHashSet<System.String>.Empty);
+            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableHashSet<global::System.Int32>.Empty);
+            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableHashSet<global::System.String>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableHashSet<global::System.String>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -148,7 +148,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Immutable.IImmutableSet<System.Int32> SomeProperty
+        public global::System.Collections.Immutable.IImmutableSet<global::System.Int32> SomeProperty
         {
             get
             {
@@ -156,17 +156,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Immutable.IImmutableSet<System.String> SomeMethod()
+        public global::System.Collections.Immutable.IImmutableSet<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableSet<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableSet<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Immutable.IImmutableSet<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableSet<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -176,7 +176,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public ICustomIImmutableSet<System.Int32> SomeCustomProperty
+        public ICustomIImmutableSet<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -184,12 +184,12 @@ namespace The.Namespace
             }
         }
 
-        public ICustomIImmutableSet<System.String> SomeMethod()
+        public ICustomIImmutableSet<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public ICustomIImmutableSet<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public ICustomIImmutableSet<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -201,7 +201,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -216,7 +216,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableHashSet<T>.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableHashSet<T>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableHashSet<T>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableHashSet<T>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -238,7 +238,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableSet<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableSet<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableStacksOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ImmutableStacksOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomImmutableStack<T>>, global::ICustomImmutableStack<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -56,7 +56,7 @@ namespace The.Namespace
             return this.Apply(x => x.Peek());
         }
 
-        public System.Boolean IsEmpty
+        public global::System.Boolean IsEmpty
         {
             get
             {
@@ -71,7 +71,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -84,9 +84,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableStack<System.Int32>.Empty);
-            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableStack<System.String>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableStack<System.String>.Empty);
+            this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableStack<global::System.Int32>.Empty);
+            this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableStack<global::System.String>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableStack<global::System.String>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -95,7 +95,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Immutable.IImmutableStack<System.Int32> SomeProperty
+        public global::System.Collections.Immutable.IImmutableStack<global::System.Int32> SomeProperty
         {
             get
             {
@@ -103,17 +103,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Immutable.IImmutableStack<System.String> SomeMethod()
+        public global::System.Collections.Immutable.IImmutableStack<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableStack<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableStack<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Immutable.IImmutableStack<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Immutable.IImmutableStack<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -123,7 +123,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public ICustomIImmutableStack<System.Int32> SomeCustomProperty
+        public ICustomIImmutableStack<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -131,12 +131,12 @@ namespace The.Namespace
             }
         }
 
-        public ICustomIImmutableStack<System.String> SomeMethod()
+        public ICustomIImmutableStack<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public ICustomIImmutableStack<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public ICustomIImmutableStack<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -148,7 +148,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -163,7 +163,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Collections.Immutable.ImmutableStack<T>.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Collections.Immutable.ImmutableStack<T>.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Collections.Immutable.ImmutableStack<T>.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Collections.Immutable.ImmutableStack<T>.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -185,7 +185,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Immutable.IImmutableStack<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Immutable.IImmutableStack<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ListsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/ListsOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomList<T>>, global::ICustomList<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -33,22 +33,22 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 IndexOf(T item)
+        public global::System.Int32 IndexOf(T item)
         {
             return this.Apply(x => x.IndexOf(item));
         }
 
-        public void Insert(System.Int32 index, T item)
+        public void Insert(global::System.Int32 index, T item)
         {
             this.Apply(x => x.Insert(index, item));
         }
 
-        public void RemoveAt(System.Int32 index)
+        public void RemoveAt(global::System.Int32 index)
         {
             this.Apply(x => x.RemoveAt(index));
         }
 
-        public T this[System.Int32 index]
+        public T this[global::System.Int32 index]
         {
             get
             {
@@ -71,22 +71,22 @@ namespace The.Namespace
             this.Apply(x => x.Clear());
         }
 
-        public System.Boolean Contains(T item)
+        public global::System.Boolean Contains(T item)
         {
             return this.Apply(x => x.Contains(item));
         }
 
-        public void CopyTo(T[] array, System.Int32 arrayIndex)
+        public void CopyTo(T[] array, global::System.Int32 arrayIndex)
         {
             this.Apply(x => x.CopyTo(array, arrayIndex));
         }
 
-        public System.Boolean Remove(T item)
+        public global::System.Boolean Remove(T item)
         {
             return this.Apply(x => x.Remove(item));
         }
 
-        public System.Int32 Count
+        public global::System.Int32 Count
         {
             get
             {
@@ -94,7 +94,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Boolean IsReadOnly
+        public global::System.Boolean IsReadOnly
         {
             get
             {
@@ -109,7 +109,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -122,10 +122,10 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<System.Int32>());
-            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.List<System.Int32>());
-            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<System.String>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.List<System.String>());
+            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<global::System.Int32>());
+            this.When(x => x.SomeReadOnlyProperty).Return(new global::System.Collections.Generic.List<global::System.Int32>());
+            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<global::System.String>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.List<global::System.String>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -134,7 +134,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.IList<System.Int32> SomeProperty
+        public global::System.Collections.Generic.IList<global::System.Int32> SomeProperty
         {
             get
             {
@@ -142,7 +142,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IReadOnlyList<System.Int32> SomeReadOnlyProperty
+        public global::System.Collections.Generic.IReadOnlyList<global::System.Int32> SomeReadOnlyProperty
         {
             get
             {
@@ -150,17 +150,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.IList<System.String> SomeMethod()
+        public global::System.Collections.Generic.IList<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IList<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IList<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Generic.IList<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Generic.IList<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -170,7 +170,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomList<System.Int32> SomeCustomProperty
+        public global::ICustomList<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -178,12 +178,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomList<System.String> SomeMethod()
+        public global::ICustomList<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomList<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomList<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -195,7 +195,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -210,7 +210,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<T>());
             this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.List<T>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.List<T>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.List<T>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -232,7 +232,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.IList<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.IList<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/RecursiveOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/RecursiveOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<System.Int32>>>());
+            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.List<global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::System.Int32>>>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -34,7 +34,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<System.Int32>>> SomeProperty
+        public global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::System.Collections.Generic.IList<global::System.Int32>>> SomeProperty
         {
             get
             {

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/SetsOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/CollectionsFixtureResources/SetsOutput_CSharp.txt
@@ -12,7 +12,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ICustomSet<T>>, global::ICustomSet<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -33,7 +33,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Boolean Add(T item)
+        public global::System.Boolean Add(T item)
         {
             return this.Apply(x => x.Add(item));
         }
@@ -58,32 +58,32 @@ namespace The.Namespace
             this.Apply(x => x.SymmetricExceptWith(other));
         }
 
-        public System.Boolean IsSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsSubsetOf(other));
         }
 
-        public System.Boolean IsSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsSupersetOf(other));
         }
 
-        public System.Boolean IsProperSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsProperSupersetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsProperSupersetOf(other));
         }
 
-        public System.Boolean IsProperSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean IsProperSubsetOf(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.IsProperSubsetOf(other));
         }
 
-        public System.Boolean Overlaps(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean Overlaps(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.Overlaps(other));
         }
 
-        public System.Boolean SetEquals(global::System.Collections.Generic.IEnumerable<T> other)
+        public global::System.Boolean SetEquals(global::System.Collections.Generic.IEnumerable<T> other)
         {
             return this.Apply(x => x.SetEquals(other));
         }
@@ -98,22 +98,22 @@ namespace The.Namespace
             this.Apply(x => x.Clear());
         }
 
-        public System.Boolean Contains(T item)
+        public global::System.Boolean Contains(T item)
         {
             return this.Apply(x => x.Contains(item));
         }
 
-        public void CopyTo(T[] array, System.Int32 arrayIndex)
+        public void CopyTo(T[] array, global::System.Int32 arrayIndex)
         {
             this.Apply(x => x.CopyTo(array, arrayIndex));
         }
 
-        public System.Boolean Remove(T item)
+        public global::System.Boolean Remove(T item)
         {
             return this.Apply(x => x.Remove(item));
         }
 
-        public System.Int32 Count
+        public global::System.Int32 Count
         {
             get
             {
@@ -121,7 +121,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Boolean IsReadOnly
+        public global::System.Boolean IsReadOnly
         {
             get
             {
@@ -136,7 +136,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -149,9 +149,9 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.HashSet<System.Int32>());
-            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.HashSet<System.String>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.HashSet<System.String>());
+            this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.HashSet<global::System.Int32>());
+            this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.HashSet<global::System.String>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.HashSet<global::System.String>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -160,7 +160,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Collections.Generic.ISet<System.Int32> SomeProperty
+        public global::System.Collections.Generic.ISet<global::System.Int32> SomeProperty
         {
             get
             {
@@ -168,17 +168,17 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Collections.Generic.ISet<System.String> SomeMethod()
+        public global::System.Collections.Generic.ISet<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.ISet<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.ISet<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
 
-        public global::System.Collections.Generic.ISet<System.Int32> SomeGenericMethod<T>()
+        public global::System.Collections.Generic.ISet<global::System.Int32> SomeGenericMethod<T>()
         {
             return this.Apply(x => x.SomeGenericMethod<T>());
         }
@@ -188,7 +188,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeOtherGenericMethod<T>());
         }
 
-        public global::ICustomSet<System.Int32> SomeCustomProperty
+        public global::ICustomSet<global::System.Int32> SomeCustomProperty
         {
             get
             {
@@ -196,12 +196,12 @@ namespace The.Namespace
             }
         }
 
-        public global::ICustomSet<System.String> SomeMethod()
+        public global::ICustomSet<global::System.String> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomSet<System.String> SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomSet<global::System.String> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -213,7 +213,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeGenericInterface<T>>, global::ISomeGenericInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -228,7 +228,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(new global::System.Collections.Generic.HashSet<T>());
             this.When(x => x.SomeMethod()).Return(new global::System.Collections.Generic.HashSet<T>());
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(new global::System.Collections.Generic.HashSet<T>());
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(new global::System.Collections.Generic.HashSet<T>());
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -250,7 +250,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Collections.Generic.ISet<T> SomeMethod(System.Int32 i, System.Single f)
+        public global::System.Collections.Generic.ISet<T> SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/DisposablesFixtureResources/DisposablesOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/DisposablesFixtureResources/DisposablesOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -19,7 +19,7 @@ namespace The.Namespace
         {
             this.When(x => x.SomeProperty).Return(global::System.Reactive.Disposables.Disposable.Empty);
             this.When(x => x.SomeMethod()).Return(global::System.Reactive.Disposables.Disposable.Empty);
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>())).Return(global::System.Reactive.Disposables.Disposable.Empty);
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>())).Return(global::System.Reactive.Disposables.Disposable.Empty);
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -41,7 +41,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.IDisposable SomeMethod(System.Int32 i, System.Single f)
+        public global::System.IDisposable SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }
@@ -69,7 +69,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomDisposable SomeMethod(System.Int32 i, System.Single f)
+        public global::ICustomDisposable SomeMethod(global::System.Int32 i, global::System.Single f)
         {
             return this.Apply(x => x.SomeMethod(i, f));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/GenericInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/GenericInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeInterface<T>>, global::ISomeInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -18,7 +18,7 @@ namespace The.Namespace
         private void ConfigureBehaviorGenerated()
         {
             this.When(x => x.SomeProperty).Return(global::System.Reactive.Linq.Observable.Empty<T>());
-            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<T>(default (T)));
+            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<T>(default(T)));
         }
 
         private void ConfigureLooseBehaviorGenerated()

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/NonObservableBasedOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/NonObservableBasedOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 SomeProperty
+        public global::System.Int32 SomeProperty
         {
             get
             {
@@ -33,7 +33,7 @@ namespace The.Namespace
             }
         }
 
-        public System.String SomeOtherProperty
+        public global::System.String SomeOtherProperty
         {
             get
             {
@@ -41,7 +41,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Int32 this[System.Int32 i, System.Single f]
+        public global::System.Int32 this[global::System.Int32 i, global::System.Single f]
         {
             get
             {
@@ -54,27 +54,27 @@ namespace The.Namespace
             this.Apply(x => x.SomeMethod());
         }
 
-        public System.String SomeMethod()
+        public global::System.String SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Int32 SomeMethod()
+        public global::System.Int32 SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Object SomeMethod()
+        public global::System.Object SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Int32 SomeMethod<T>()
+        public global::System.Int32 SomeMethod<T>()
         {
             return this.Apply(x => x.SomeMethod<T>());
         }
 
-        public System.Int32 SomeMethod<T1, T2>()
+        public global::System.Int32 SomeMethod<T1, T2>()
         {
             return this.Apply(x => x.SomeMethod<T1, T2>());
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/ObservableBasedOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/ObservableBasedOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,11 +17,11 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Reactive.Linq.Observable.Empty<System.Int32>());
-            this.When(x => x.SomeOtherProperty).Return(global::System.Reactive.Linq.Observable.Empty<System.String>());
-            this.When(x => x[global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>()]).Return(global::System.Reactive.Linq.Observable.Empty<System.Int32>());
-            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<System.Int32>(0));
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.String>(), global::PCLMock.It.IsAny<System.Int32>())).Return(global::System.Reactive.Linq.Observable.Return<System.String>(null));
+            this.When(x => x.SomeProperty).Return(global::System.Reactive.Linq.Observable.Empty<global::System.Int32>());
+            this.When(x => x.SomeOtherProperty).Return(global::System.Reactive.Linq.Observable.Empty<global::System.String>());
+            this.When(x => x[global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>()]).Return(global::System.Reactive.Linq.Observable.Empty<global::System.Int32>());
+            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<global::System.Int32>(0));
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.String>(), global::PCLMock.It.IsAny<global::System.Int32>())).Return(global::System.Reactive.Linq.Observable.Return<global::System.String>(null));
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -30,7 +30,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.IObservable<System.Int32> SomeProperty
+        public global::System.IObservable<global::System.Int32> SomeProperty
         {
             get
             {
@@ -38,7 +38,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.IObservable<System.String> SomeOtherProperty
+        public global::System.IObservable<global::System.String> SomeOtherProperty
         {
             get
             {
@@ -46,7 +46,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.IObservable<System.Int32> this[System.Int32 i, System.Single f]
+        public global::System.IObservable<global::System.Int32> this[global::System.Int32 i, global::System.Single f]
         {
             get
             {
@@ -54,32 +54,32 @@ namespace The.Namespace
             }
         }
 
-        public global::System.IObservable<System.Int32> SomeMethod()
+        public global::System.IObservable<global::System.Int32> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.IObservable<System.String> SomeMethod(System.String s, System.Int32 i)
+        public global::System.IObservable<global::System.String> SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }
 
-        public global::System.IObservable<System.Int32> SomeMethod<T>()
+        public global::System.IObservable<global::System.Int32> SomeMethod<T>()
         {
             return this.Apply(x => x.SomeMethod<T>());
         }
 
-        public global::System.IObservable<System.Int32> SomeMethod<T1, T2>()
+        public global::System.IObservable<global::System.Int32> SomeMethod<T1, T2>()
         {
             return this.Apply(x => x.SomeMethod<T1, T2>());
         }
 
-        public global::ICustomObservable<System.Int32> SomeMethod()
+        public global::ICustomObservable<global::System.Int32> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::ICustomObservable<System.String> SomeMethod(System.String s, System.Int32 i)
+        public global::ICustomObservable<global::System.String> SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/RecursiveOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/ObservableBasedAsynchronyFixtureResources/RecursiveOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,7 +17,7 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<global::System.IObservable<System.Int32>>(global::System.Reactive.Linq.Observable.Return<System.Int32>(0)));
+            this.When(x => x.SomeMethod()).Return(global::System.Reactive.Linq.Observable.Return<global::System.IObservable<global::System.Int32>>(global::System.Reactive.Linq.Observable.Return<global::System.Int32>(0)));
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -26,7 +26,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.IObservable<global::System.IObservable<System.Int32>> SomeMethod()
+        public global::System.IObservable<global::System.IObservable<global::System.Int32>> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/GenericInterfaceOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/GenericInterfaceOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock<T> : global::PCLMock.MockBase<global::ISomeInterface<T>>, global::ISomeInterface<T>
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,8 +17,8 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<T>(default (T)));
-            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<T>(default (T)));
+            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<T>(default(T)));
+            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<T>(default(T)));
         }
 
         private void ConfigureLooseBehaviorGenerated()

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/GenericTaskOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/GenericTaskOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,11 +17,11 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<System.Int32>(0));
-            this.When(x => x.SomeOtherProperty).Return(global::System.Threading.Tasks.Task.FromResult<System.String>(null));
-            this.When(x => x[global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>()]).Return(global::System.Threading.Tasks.Task.FromResult<System.Int32>(0));
-            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<System.Int32>(0));
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.String>(), global::PCLMock.It.IsAny<System.Int32>())).Return(global::System.Threading.Tasks.Task.FromResult<System.String>(null));
+            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Int32>(0));
+            this.When(x => x.SomeOtherProperty).Return(global::System.Threading.Tasks.Task.FromResult<global::System.String>(null));
+            this.When(x => x[global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>()]).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Int32>(0));
+            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Int32>(0));
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.String>(), global::PCLMock.It.IsAny<global::System.Int32>())).Return(global::System.Threading.Tasks.Task.FromResult<global::System.String>(null));
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -30,7 +30,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Threading.Tasks.Task<System.Int32> SomeProperty
+        public global::System.Threading.Tasks.Task<global::System.Int32> SomeProperty
         {
             get
             {
@@ -38,7 +38,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Threading.Tasks.Task<System.String> SomeOtherProperty
+        public global::System.Threading.Tasks.Task<global::System.String> SomeOtherProperty
         {
             get
             {
@@ -46,7 +46,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Threading.Tasks.Task<System.Int32> this[System.Int32 i, System.Single f]
+        public global::System.Threading.Tasks.Task<global::System.Int32> this[global::System.Int32 i, global::System.Single f]
         {
             get
             {
@@ -54,32 +54,32 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Threading.Tasks.Task<System.Int32> SomeMethod()
+        public global::System.Threading.Tasks.Task<global::System.Int32> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Threading.Tasks.Task<System.String> SomeMethod(System.String s, System.Int32 i)
+        public global::System.Threading.Tasks.Task<global::System.String> SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }
 
-        public global::System.Threading.Tasks.Task<System.Int32> SomeMethod<T>()
+        public global::System.Threading.Tasks.Task<global::System.Int32> SomeMethod<T>()
         {
             return this.Apply(x => x.SomeMethod<T>());
         }
 
-        public global::System.Threading.Tasks.Task<System.Int32> SomeMethod<T1, T2>()
+        public global::System.Threading.Tasks.Task<global::System.Int32> SomeMethod<T1, T2>()
         {
             return this.Apply(x => x.SomeMethod<T1, T2>());
         }
 
-        public global::CustomTask<System.Int32> SomeMethod()
+        public global::CustomTask<global::System.Int32> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::CustomTask<System.String> SomeMethod(System.String s, System.Int32 i)
+        public global::CustomTask<global::System.String> SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/NonGenericTaskOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/NonGenericTaskOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,11 +17,11 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<System.Boolean>(false));
-            this.When(x => x.SomeOtherProperty).Return(global::System.Threading.Tasks.Task.FromResult<System.Boolean>(false));
-            this.When(x => x[global::PCLMock.It.IsAny<System.Int32>(), global::PCLMock.It.IsAny<System.Single>()]).Return(global::System.Threading.Tasks.Task.FromResult<System.Boolean>(false));
-            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<System.Boolean>(false));
-            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<System.String>(), global::PCLMock.It.IsAny<System.Int32>())).Return(global::System.Threading.Tasks.Task.FromResult<System.Boolean>(false));
+            this.When(x => x.SomeProperty).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Boolean>(false));
+            this.When(x => x.SomeOtherProperty).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Boolean>(false));
+            this.When(x => x[global::PCLMock.It.IsAny<global::System.Int32>(), global::PCLMock.It.IsAny<global::System.Single>()]).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Boolean>(false));
+            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Boolean>(false));
+            this.When(x => x.SomeMethod(global::PCLMock.It.IsAny<global::System.String>(), global::PCLMock.It.IsAny<global::System.Int32>())).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Boolean>(false));
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -46,7 +46,7 @@ namespace The.Namespace
             }
         }
 
-        public global::System.Threading.Tasks.Task this[System.Int32 i, System.Single f]
+        public global::System.Threading.Tasks.Task this[global::System.Int32 i, global::System.Single f]
         {
             get
             {
@@ -59,7 +59,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::System.Threading.Tasks.Task SomeMethod(System.String s, System.Int32 i)
+        public global::System.Threading.Tasks.Task SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }
@@ -79,7 +79,7 @@ namespace The.Namespace
             return this.Apply(x => x.SomeMethod());
         }
 
-        public global::CustomTask SomeMethod(System.String s, System.Int32 i)
+        public global::CustomTask SomeMethod(global::System.String s, global::System.Int32 i)
         {
             return this.Apply(x => x.SomeMethod(s, i));
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/NonTaskBasedOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/NonTaskBasedOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -25,7 +25,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public System.Int32 SomeProperty
+        public global::System.Int32 SomeProperty
         {
             get
             {
@@ -33,7 +33,7 @@ namespace The.Namespace
             }
         }
 
-        public System.String SomeOtherProperty
+        public global::System.String SomeOtherProperty
         {
             get
             {
@@ -41,7 +41,7 @@ namespace The.Namespace
             }
         }
 
-        public System.Int32 this[System.Int32 i, System.Single f]
+        public global::System.Int32 this[global::System.Int32 i, global::System.Single f]
         {
             get
             {
@@ -54,27 +54,27 @@ namespace The.Namespace
             this.Apply(x => x.SomeMethod());
         }
 
-        public System.String SomeMethod()
+        public global::System.String SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Int32 SomeMethod()
+        public global::System.Int32 SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Object SomeMethod()
+        public global::System.Object SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }
 
-        public System.Int32 SomeMethod<T>()
+        public global::System.Int32 SomeMethod<T>()
         {
             return this.Apply(x => x.SomeMethod<T>());
         }
 
-        public System.Int32 SomeMethod<T1, T2>()
+        public global::System.Int32 SomeMethod<T1, T2>()
         {
             return this.Apply(x => x.SomeMethod<T1, T2>());
         }

--- a/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/RecursiveOutput_CSharp.txt
+++ b/Src/PCLMock.UnitTests/CodeGeneration/Plugins/TaskBasedAsynchronyFixtureResources/RecursiveOutput_CSharp.txt
@@ -4,7 +4,7 @@ namespace The.Namespace
     [System.Runtime.CompilerServices.CompilerGenerated]
     internal partial class Mock : global::PCLMock.MockBase<global::ISomeInterface>, global::ISomeInterface
     {
-        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base (behavior)
+        public Mock(global::PCLMock.MockBehavior behavior = global::PCLMock.MockBehavior.Strict): base(behavior)
         {
             ConfigureBehaviorGenerated();
             ConfigureBehavior();
@@ -17,7 +17,7 @@ namespace The.Namespace
 
         private void ConfigureBehaviorGenerated()
         {
-            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Threading.Tasks.Task<System.Int32>>(global::System.Threading.Tasks.Task.FromResult<System.Int32>(0)));
+            this.When(x => x.SomeMethod()).Return(global::System.Threading.Tasks.Task.FromResult<global::System.Threading.Tasks.Task<global::System.Int32>>(global::System.Threading.Tasks.Task.FromResult<global::System.Int32>(0)));
         }
 
         private void ConfigureLooseBehaviorGenerated()
@@ -26,7 +26,7 @@ namespace The.Namespace
 
         partial void ConfigureBehavior();
         partial void ConfigureLooseBehavior();
-        public global::System.Threading.Tasks.Task<global::System.Threading.Tasks.Task<System.Int32>> SomeMethod()
+        public global::System.Threading.Tasks.Task<global::System.Threading.Tasks.Task<global::System.Int32>> SomeMethod()
         {
             return this.Apply(x => x.SomeMethod());
         }

--- a/Src/PCLMock.UnitTests/PCLMock.UnitTests.csproj
+++ b/Src/PCLMock.UnitTests/PCLMock.UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PCLMock.UnitTests</RootNamespace>
     <AssemblyName>PCLMock.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/Src/PCLMock.UnitTests/PCLMock.UnitTests.csproj
+++ b/Src/PCLMock.UnitTests/PCLMock.UnitTests.csproj
@@ -35,61 +35,71 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeAnalysis, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.3.2\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.2.8.2\lib\netstandard1.3\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.3.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.3.2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=2.8.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.2.8.2\lib\net46\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Collections.Immutable.1.3.1\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Composition.AttributedModel, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.AttributedModel, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.AttributedModel.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Convention, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Convention, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Convention.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Hosting, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Hosting, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Hosting.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.Runtime, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.Runtime, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.Runtime.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="System.Composition.TypedParts, Version=1.0.30.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Composition.1.0.30\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Composition.TypedParts, Version=1.0.31.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Composition.TypedParts.1.0.31\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.FileVersionInfo, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.FileVersionInfo.4.3.0\lib\net46\System.Diagnostics.FileVersionInfo.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Diagnostics.StackTrace, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Numerics" />
     <Reference Include="System.Reactive.Core, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Rx-Core.2.2.5\lib\net45\System.Reactive.Core.dll</HintPath>
       <Private>True</Private>
@@ -110,11 +120,44 @@
       <HintPath>..\packages\System.Reflection.Metadata.1.4.2\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net46\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Encoding.CodePages, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encoding.CodePages.4.3.0\lib\net46\System.Text.Encoding.CodePages.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Thread, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Thread.4.3.0\lib\net46\System.Threading.Thread.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.ReaderWriter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.ReaderWriter.4.3.0\lib\net46\System.Xml.ReaderWriter.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.4.3.0\lib\net46\System.Xml.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.XPath.XDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XPath.XDocument.4.3.0\lib\net46\System.Xml.XPath.XDocument.dll</HintPath>
+    </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -240,10 +283,6 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="CodeGeneration\Models\ConfigurationFixtureResources\Input.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="CodeGeneration\GeneratorFixtureResources\InternalInterfaceOutput_CSharp.txt" />
@@ -382,6 +421,10 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="CodeGeneration\Plugins\TaskBasedAsynchronyFixtureResources\RecursiveOutput_CSharp.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.2.6.1\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/Src/PCLMock.UnitTests/app.config
+++ b/Src/PCLMock.UnitTests/app.config
@@ -28,4 +28,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>

--- a/Src/PCLMock.UnitTests/packages.config
+++ b/Src/PCLMock.UnitTests/packages.config
@@ -1,25 +1,42 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.3.2" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.3.2" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="2.6.1" targetFramework="net46" developmentDependency="true" />
+  <package id="Microsoft.CodeAnalysis.Common" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="2.8.2" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="2.8.2" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net45" />
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="System.AppContext" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.3.1" targetFramework="net452" />
+  <package id="System.Composition" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.AttributedModel" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Convention" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Hosting" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.Runtime" version="1.0.31" targetFramework="net46" />
+  <package id="System.Composition.TypedParts" version="1.0.31" targetFramework="net46" />
+  <package id="System.Console" version="4.3.0" targetFramework="net46" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.FileVersionInfo" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.StackTrace" version="4.3.0" targetFramework="net46" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net46" />
+  <package id="System.Dynamic.Runtime" version="4.3.0" targetFramework="net46" />
   <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
   <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net46" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.4.2" targetFramework="net452" />
@@ -28,9 +45,24 @@
   <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.CodePages" version="4.3.0" targetFramework="net46" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Tasks.Parallel" version="4.3.0" targetFramework="net46" />
+  <package id="System.Threading.Thread" version="4.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath" version="4.3.0" targetFramework="net46" />
+  <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net46" />
   <package id="xunit" version="2.2.0" targetFramework="net452" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net452" />


### PR DESCRIPTION
I have an issue with the newest nuget of PCLMock (4.0.0 right now), and it seems reproducible in current master. When I launch console with only vs2017 installed, I've got the following exception:
```
Failed to generate code: System.AggregateException: One or more errors occurred. ---> System.IO.FileNotFoundException: Could not load file or assembly 'System.Threading.Tasks.Dataflow, Version=4.5.24.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The system cannot find the file specified.
3>               at Microsoft.Build.BackEnd.Logging.LoggingService.ProcessLoggingEvent(Object buildEvent, Boolean allowThrottling)
3>               at Microsoft.Build.BackEnd.Logging.LoggingService.LogInvalidProjectFileError(BuildEventContext buildEventContext, InvalidProjectFileException invalidProjectFileException)
3>               at Microsoft.Build.Evaluation.Project.ReevaluateIfNecessary(ILoggingService loggingServiceForEvaluation)
3>               at Microsoft.Build.Evaluation.Project.Initialize(IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectLoadSettings loadSettings)
3>               at Microsoft.Build.Evaluation.Project..ctor(ProjectRootElement xml, IDictionary`2 globalProperties, String toolsVersion, String subToolsetVersion, ProjectCollection projectCollection, ProjectLoadSettings loadSettings)
3>               at Microsoft.CodeAnalysis.MSBuild.ProjectFileLoader.<LoadProjectAsync>d__5.MoveNext()
```

This may be fixed by putting the dll into GAC, but you have to do it on every developer's machine. Therefore I tried to upgrade Microsoft.CodeAnalysis nuget packages to the newest versions and it fixed the problem for me.

I had to increase minimum .Net framework version because the newest nugets rely on .Net standard 1.3 which is implemented for .Net 4.6.0 and newer.